### PR TITLE
Make it work without debloating /system

### DIFF
--- a/build/Android.executable.mk
+++ b/build/Android.executable.mk
@@ -50,6 +50,7 @@ define build-art-executable
   art_target_or_host := $(5)
   art_ndebug_or_debug := $(6)
   art_multilib := $(7)
+  art_static_libraries := $(8)
 
   include $(CLEAR_VARS)
   LOCAL_CPP_EXTENSION := $(ART_CPP_EXTENSION)
@@ -57,6 +58,7 @@ define build-art-executable
   LOCAL_SRC_FILES := $$(art_source)
   LOCAL_C_INCLUDES += $(ART_C_INCLUDES) art/runtime $$(art_c_includes)
   LOCAL_SHARED_LIBRARIES += $$(art_shared_libraries)
+  LOCAL_STATIC_LIBRARIES += $$(art_static_libraries)
 
   ifeq ($$(art_ndebug_or_debug),ndebug)
     LOCAL_MODULE := $$(art_executable)

--- a/compiler/dex/dex_to_dex_compiler.cc
+++ b/compiler/dex/dex_to_dex_compiler.cc
@@ -226,8 +226,10 @@ void DexCompiler::CompileInstanceFieldAccess(Instruction* inst,
   }
 }
 
-void DexCompiler::CompileInvokeVirtual(Instruction* inst, uint32_t dex_pc,
-                                       Instruction::Code new_opcode, bool is_range) {
+void DexCompiler::CompileInvokeVirtual(Instruction* inst,
+                                uint32_t dex_pc,
+                                Instruction::Code new_opcode,
+                                bool is_range) {
   if (!kEnableQuickening || !PerformOptimizations()) {
     return;
   }

--- a/compiler/dex/mir_method_info.cc
+++ b/compiler/dex/mir_method_info.cc
@@ -57,7 +57,6 @@ void MirMethodLoweringInfo::Resolve(CompilerDriver* compiler_driver,
   auto current_dex_cache(hs.NewHandle<mirror::DexCache>(nullptr));
   // Even if the referrer class is unresolved (i.e. we're compiling a method without class
   // definition) we still want to resolve methods and record all available info.
-  Runtime* const runtime = Runtime::Current();
   const DexFile* const dex_file = mUnit->GetDexFile();
   const VerifiedMethod* const verified_method = mUnit->GetVerifiedMethod();
 
@@ -80,7 +79,7 @@ void MirMethodLoweringInfo::Resolve(CompilerDriver* compiler_driver,
       it->target_method_idx_ = it->MethodIndex();
       current_dex_cache.Assign(dex_cache.Get());
       resolved_method = compiler_driver->ResolveMethod(soa, dex_cache, class_loader, mUnit,
-                                                       it->target_method_idx_, invoke_type, true);
+                                                       it->MethodIndex(), invoke_type);
     } else {
       // The method index is actually the dex PC in this case.
       // Calculate the proper dex file and target method idx.
@@ -88,7 +87,8 @@ void MirMethodLoweringInfo::Resolve(CompilerDriver* compiler_driver,
       // Don't devirt if we are in a different dex file since we can't have direct invokes in
       // another dex file unless we always put a direct / patch pointer.
       devirt_target = nullptr;
-      current_dex_cache.Assign(runtime->GetClassLinker()->FindDexCache(*it->target_dex_file_));
+      current_dex_cache.Assign(
+          Runtime::Current()->GetClassLinker()->FindDexCache(*it->target_dex_file_));
       CHECK(current_dex_cache.Get() != nullptr);
       DexCompilationUnit cu(
           mUnit->GetCompilationUnit(), mUnit->GetClassLoader(), mUnit->GetClassLinker(),
@@ -97,14 +97,6 @@ void MirMethodLoweringInfo::Resolve(CompilerDriver* compiler_driver,
           nullptr /* verified_method not used */);
       resolved_method = compiler_driver->ResolveMethod(soa, current_dex_cache, class_loader, &cu,
                                                        it->target_method_idx_, invoke_type, false);
-      if (resolved_method == nullptr) {
-        // If the method is null then it should be a miranda method, in this case try
-        // re-loading it, this time as an interface method. The actual miranda method is in the
-        // vtable, but it will resolve to an interface method.
-        resolved_method = compiler_driver->ResolveMethod(
-            soa, current_dex_cache, class_loader, &cu, it->target_method_idx_, kInterface, false);
-        CHECK(resolved_method != nullptr);
-      }
       if (resolved_method != nullptr) {
         // Since this was a dequickened virtual, it is guaranteed to be resolved. However, it may be
         // resolved to an interface method. If this is the case then change the invoke type to
@@ -129,9 +121,10 @@ void MirMethodLoweringInfo::Resolve(CompilerDriver* compiler_driver,
       it->vtable_idx_ =
           compiler_driver->GetResolvedMethodVTableIndex(resolved_method, invoke_type);
     }
+
     MethodReference target_method(it->target_dex_file_, it->target_method_idx_);
     int fast_path_flags = compiler_driver->IsFastInvoke(
-        soa, current_dex_cache, class_loader, mUnit, referrer_class.Get(), resolved_method, &invoke_type,
+        soa, dex_cache, class_loader, mUnit, referrer_class.Get(), resolved_method, &invoke_type,
         &target_method, devirt_target, &it->direct_code_, &it->direct_method_, it->IsQuickened());
     bool needs_clinit =
         compiler_driver->NeedsClassInitialization(referrer_class.Get(), resolved_method);

--- a/compiler/dex/verified_method.cc
+++ b/compiler/dex/verified_method.cc
@@ -60,9 +60,7 @@ const VerifiedMethod* VerifiedMethod::Create(verifier::MethodVerifier* method_ve
       verified_method->GenerateDevirtMap(method_verifier);
     }
 
-    if (!verified_method->GenerateDequickenMap(method_verifier)) {
-      return nullptr;
-    }
+    verified_method->GenerateDequickenMap(method_verifier);
   }
 
   if (method_verifier->HasCheckCasts()) {
@@ -198,9 +196,9 @@ void VerifiedMethod::ComputeGcMapSizes(verifier::MethodVerifier* method_verifier
   *log2_max_gc_pc = i;
 }
 
-bool VerifiedMethod::GenerateDequickenMap(verifier::MethodVerifier* method_verifier) {
+void VerifiedMethod::GenerateDequickenMap(verifier::MethodVerifier* method_verifier) {
   if (method_verifier->HasFailures()) {
-    return false;
+    return;
   }
   const DexFile::CodeItem* code_item = method_verifier->CodeItem();
   const uint16_t* insns = code_item->insns_;
@@ -214,12 +212,9 @@ bool VerifiedMethod::GenerateDequickenMap(verifier::MethodVerifier* method_verif
     if (is_virtual_quick || is_range_quick) {
       uint32_t dex_pc = inst->GetDexPc(insns);
       verifier::RegisterLine* line = method_verifier->GetRegLine(dex_pc);
-      mirror::ArtMethod* method =
-          method_verifier->GetQuickInvokedMethod(inst, line, is_range_quick, true);
-      if (method == nullptr) {
-        // It can be null if the line wasn't verified since it was unreachable.
-        return false;
-      }
+      mirror::ArtMethod* method = method_verifier->GetQuickInvokedMethod(inst, line,
+                                                                         is_range_quick);
+      CHECK(method != nullptr);
       // The verifier must know what the type of the object was or else we would have gotten a
       // failure. Put the dex method index in the dequicken map since we need this to get number of
       // arguments in the compiler.
@@ -229,10 +224,7 @@ bool VerifiedMethod::GenerateDequickenMap(verifier::MethodVerifier* method_verif
       uint32_t dex_pc = inst->GetDexPc(insns);
       verifier::RegisterLine* line = method_verifier->GetRegLine(dex_pc);
       mirror::ArtField* field = method_verifier->GetQuickFieldAccess(inst, line);
-      if (field == nullptr) {
-        // It can be null if the line wasn't verified since it was unreachable.
-        return false;
-      }
+      CHECK(field != nullptr);
       // The verifier must know what the type of the field was or else we would have gotten a
       // failure. Put the dex field index in the dequicken map since we need this for lowering
       // in the compiler.
@@ -240,7 +232,6 @@ bool VerifiedMethod::GenerateDequickenMap(verifier::MethodVerifier* method_verif
       dequicken_map_.Put(dex_pc, DexFileReference(field->GetDexFile(), field->GetDexFieldIndex()));
     }
   }
-  return true;
 }
 
 void VerifiedMethod::GenerateDevirtMap(verifier::MethodVerifier* method_verifier) {

--- a/compiler/dex/verified_method.h
+++ b/compiler/dex/verified_method.h
@@ -93,8 +93,8 @@ class VerifiedMethod {
   void GenerateDevirtMap(verifier::MethodVerifier* method_verifier)
       SHARED_LOCKS_REQUIRED(Locks::mutator_lock_);
 
-  // Generate dequickening map into dequicken_map_. Returns false if there is an error.
-  bool GenerateDequickenMap(verifier::MethodVerifier* method_verifier)
+  // Generate dequickening map into dequicken_map_.
+  void GenerateDequickenMap(verifier::MethodVerifier* method_verifier)
       SHARED_LOCKS_REQUIRED(Locks::mutator_lock_);
 
   // Generate safe case set into safe_cast_set_.

--- a/dex2oat/Android.mk
+++ b/dex2oat/Android.mk
@@ -30,15 +30,15 @@ else
 endif
 
 ifeq ($(ART_BUILD_TARGET_NDEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libart-compiler libz,art/compiler,target,ndebug,$(dex2oat_arch)))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libart-compiler,art/compiler,target,ndebug,$(dex2oat_arch),libz))
 endif
 ifeq ($(ART_BUILD_TARGET_DEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libartd-compiler libz,art/compiler,target,debug,$(dex2oat_arch)))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libartd-compiler,art/compiler,target,debug,$(dex2oat_arch),libz))
 endif
 
 ifeq ($(ART_BUILD_HOST_NDEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libart-compiler,art/compiler,host,ndebug))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libart-compiler,art/compiler,host,ndebug,,libz))
 endif
 ifeq ($(ART_BUILD_HOST_DEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libartd-compiler,art/compiler,host,debug))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libartd-compiler,art/compiler,host,debug,,libz))
 endif

--- a/dex2oat/Android.mk
+++ b/dex2oat/Android.mk
@@ -30,10 +30,10 @@ else
 endif
 
 ifeq ($(ART_BUILD_TARGET_NDEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libart-compiler,art/compiler,target,ndebug,$(dex2oat_arch)))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libart-compiler libz,art/compiler,target,ndebug,$(dex2oat_arch)))
 endif
 ifeq ($(ART_BUILD_TARGET_DEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libartd-compiler,art/compiler,target,debug,$(dex2oat_arch)))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libartd-compiler libz,art/compiler,target,debug,$(dex2oat_arch)))
 endif
 
 ifeq ($(ART_BUILD_HOST_NDEBUG),true)

--- a/dex2oat/Android.mk
+++ b/dex2oat/Android.mk
@@ -30,15 +30,15 @@ else
 endif
 
 ifeq ($(ART_BUILD_TARGET_NDEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libart-compiler,art/compiler,target,ndebug,$(dex2oat_arch),libz))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libart-compiler,art/compiler,target,ndebug,$(dex2oat_arch),libz libxz))
 endif
 ifeq ($(ART_BUILD_TARGET_DEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libartd-compiler,art/compiler,target,debug,$(dex2oat_arch),libz))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libartd-compiler,art/compiler,target,debug,$(dex2oat_arch),libz libxz))
 endif
 
 ifeq ($(ART_BUILD_HOST_NDEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libart-compiler,art/compiler,host,ndebug,,libz))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libart-compiler,art/compiler,host,ndebug,,libz libxz_host))
 endif
 ifeq ($(ART_BUILD_HOST_DEBUG),true)
-  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libartd-compiler,art/compiler,host,debug,,libz))
+  $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libartd-compiler,art/compiler,host,debug,,libz libxz_host))
 endif

--- a/dex2oat/dex2oat.cc
+++ b/dex2oat/dex2oat.cc
@@ -585,7 +585,7 @@ static File* Inflate(const std::string& filename, int out_fd, std::string* err) 
   }
 
   constexpr size_t INFLATE_BUFLEN = 16384;
-  std::unique_ptr<File> out_file(new File(out_fd, false));
+  std::unique_ptr<File> out_file(new File(out_fd));
   std::unique_ptr<Byte[]> buf(new Byte[INFLATE_BUFLEN]);
   int len;
 
@@ -666,7 +666,7 @@ static File* InflateXZ(const std::string& filename, int out_fd, std::string* err
 
        xz_dec_end(dec);
 
-       std::unique_ptr<File> out_file_ptr(new File(out_fd, false));
+       std::unique_ptr<File> out_file_ptr(new File(out_fd));
 
        if (!out_file_ptr->WriteFully(uncompressed.c_str(), uncompressed.length())) {
          *err = StringPrintf("Could not write to fd=%d", out_fd);

--- a/dex2oat/dex2oat.cc
+++ b/dex2oat/dex2oat.cc
@@ -66,6 +66,9 @@
 #include "well_known_classes.h"
 #include "zip_archive.h"
 #include "zlib.h"
+#include "xz_config.h"
+#include "xz.h"
+#include "xz_private.h"
 
 namespace art {
 
@@ -616,6 +619,115 @@ static File* Inflate(const std::string& filename, int out_fd, std::string* err) 
   return out_file.release();
 }
 
+static File* InflateXZ(const std::string& filename, int out_fd, std::string* err) {
+
+  if (out_fd == -1) {
+  *err = "No swap file available";
+  return nullptr;
+  }
+
+  struct xz_buf b;
+  struct xz_dec *dec;
+  uint8_t xz_out[BUFSIZ];
+  enum xz_ret ret;
+  std::string uncompressed;
+
+  std::ifstream t(filename.c_str());
+  std::ostringstream in_contents;
+  in_contents << t.rdbuf();
+  std::string input_str = in_contents.str();
+
+  b.in = (const uint8_t*) input_str.c_str();
+  b.in_pos = 0;
+  b.in_size = input_str.length();
+  b.out = xz_out;
+  b.out_pos = 0;
+  b.out_size = BUFSIZ;
+
+  xz_crc32_init();
+
+  xz_crc64_init();
+
+  dec = xz_dec_init(XZ_DYNALLOC, 1 << 26);
+  if(dec == NULL) {
+     LOG(WARNING) << "xz_dec_init FAILED!";
+     return nullptr;
+  }
+
+  while (b.in_pos != b.in_size) {
+     ret = xz_dec_run(dec, &b);
+     uncompressed.append((const char*) xz_out, b.out_pos);
+     b.out_pos = 0;
+
+     if (ret == XZ_OK)
+       continue;
+
+     if (ret == XZ_STREAM_END) {
+
+       xz_dec_end(dec);
+
+       std::unique_ptr<File> out_file_ptr(new File(out_fd, false));
+
+       if (!out_file_ptr->WriteFully(uncompressed.c_str(), uncompressed.length())) {
+         *err = StringPrintf("Could not write to fd=%d", out_fd);
+         return nullptr;
+       }
+
+       if (out_file_ptr->Flush() != 0) {
+         *err = StringPrintf("Could not flush swap file fd=%d", out_fd);
+         return nullptr;
+       }
+
+       out_file_ptr->DisableAutoClose();
+       return out_file_ptr.release();
+     }
+
+     if (ret == XZ_UNSUPPORTED_CHECK) {
+       LOG(WARNING) << "Unsupported check; not verifying file integrity";
+       continue;
+     }
+
+     if (ret == XZ_MEM_ERROR) {
+       LOG(ERROR) << "Memory allocation failed";
+       break;
+     }
+
+     if (ret == XZ_MEMLIMIT_ERROR) {
+       LOG(ERROR) << "Memory usage limit reached";
+       break;
+     }
+
+     if (ret == XZ_FORMAT_ERROR) {
+       LOG(ERROR) << "XZ file format error";
+       break;
+     }
+
+     if (ret == XZ_OPTIONS_ERROR) {
+       LOG(ERROR) << "Unsupported options in the .xz headers";
+       break;
+     }
+
+     if (ret == XZ_DATA_ERROR) {
+       LOG(ERROR) << "File data corrupt";
+       break;
+     }
+
+     if (ret == XZ_BUF_ERROR) {
+       LOG(ERROR) << "File buffer corrupt";
+       break;
+     } else {
+       LOG(ERROR) << "XZ Bug!";
+       break;
+     }
+
+  }
+
+  *err = StringPrintf("Could not uncompress file=%s", filename.c_str());
+  xz_dec_end(dec);
+  return nullptr;
+
+}
+
 static size_t OpenDexFiles(const std::vector<const char*>& dex_filenames,
                            const std::vector<const char*>& dex_locations,
                            std::vector<const DexFile*>& dex_files,
@@ -640,6 +752,14 @@ static size_t OpenDexFiles(const std::vector<const char*>& dex_filenames,
       }
     } else if (EndsWith(dex_filename, ".gz.xposed")) {
       file.reset(Inflate(dex_filename, swap_fd, &error_msg));
+      if (file.get() == nullptr) {
+        LOG(WARNING) << "Failed to inflate " << dex_filename << "': " << error_msg;
+        ++failure_count;
+        continue;
+      }
+      swap_fd = -1;
+    } else if (EndsWith(dex_filename, ".xz.xposed")) {
+      file.reset(InflateXZ(dex_filename, swap_fd, &error_msg));
       if (file.get() == nullptr) {
         LOG(WARNING) << "Failed to inflate " << dex_filename << "': " << error_msg;
         ++failure_count;

--- a/dex2oat/dex2oat.cc
+++ b/dex2oat/dex2oat.cc
@@ -65,6 +65,7 @@
 #include "vector_output_stream.h"
 #include "well_known_classes.h"
 #include "zip_archive.h"
+#include "zlib.h"
 
 namespace art {
 
@@ -568,9 +569,57 @@ class Dex2Oat {
   DISALLOW_IMPLICIT_CONSTRUCTORS(Dex2Oat);
 };
 
+static File* Inflate(const std::string& filename, int out_fd, std::string* err) {
+  if (out_fd == -1) {
+    *err = "No swap file available";
+    return nullptr;
+  }
+
+  gzFile in_gzfile = gzopen(filename.c_str(), "rb");
+  if (in_gzfile == nullptr) {
+    *err = StringPrintf("Could not open gzip file: %s", strerror(errno));
+    return nullptr;
+  }
+
+  constexpr size_t INFLATE_BUFLEN = 16384;
+  std::unique_ptr<File> out_file(new File(out_fd, false));
+  std::unique_ptr<Byte[]> buf(new Byte[INFLATE_BUFLEN]);
+  int len;
+
+  while (0 < (len = gzread(in_gzfile, buf.get(), INFLATE_BUFLEN)))  {
+    if (!out_file->WriteFully(buf.get(), len)) {
+      *err = StringPrintf("Could not write to fd=%d: %s", out_fd, out_file->GetPath().c_str());
+      gzclose(in_gzfile);
+      return nullptr;
+    }
+  }
+
+  int errnum;
+  const char* gzerrstr = gzerror(in_gzfile, &errnum);
+
+  if (len < 0 || errnum != Z_OK) {
+    *err = StringPrintf("Could not inflate gzip file: %s", gzerrstr);
+    gzclose(in_gzfile);
+    return nullptr;
+  }
+
+  if ((errnum = gzclose(in_gzfile)) != Z_OK) {
+    *err = StringPrintf("Could not close gzip file: gzclose() returned %d", errnum);
+  }
+
+  if (out_file->Flush() != 0) {
+    *err = StringPrintf("Could not flush swap file fd=%d", out_fd);
+    return nullptr;
+  }
+
+  out_file->DisableAutoClose();
+  return out_file.release();
+}
+
 static size_t OpenDexFiles(const std::vector<const char*>& dex_filenames,
                            const std::vector<const char*>& dex_locations,
-                           std::vector<const DexFile*>& dex_files) {
+                           std::vector<const DexFile*>& dex_files,
+                           int& swap_fd) {
   size_t failure_count = 0;
   for (size_t i = 0; i < dex_filenames.size(); i++) {
     const char* dex_filename = dex_filenames[i];
@@ -581,13 +630,24 @@ static size_t OpenDexFiles(const std::vector<const char*>& dex_filenames,
       LOG(WARNING) << "Skipping non-existent dex file '" << dex_filename << "'";
       continue;
     }
+    std::unique_ptr<File> file;
     if (EndsWith(dex_filename, ".oat") || EndsWith(dex_filename, ".odex") || EndsWith(dex_filename, ".odex.xposed")) {
-      std::unique_ptr<File> file(OS::OpenFileForReading(dex_filename));
+      file.reset(OS::OpenFileForReading(dex_filename));
       if (file.get() == nullptr) {
-        LOG(WARNING) << "Failed to open file '" << dex_filename << "': " << strerror(errno);;
+        LOG(WARNING) << "Failed to open file '" << dex_filename << "': " << strerror(errno);
         ++failure_count;
         continue;
       }
+    } else if (EndsWith(dex_filename, ".gz.xposed")) {
+      file.reset(Inflate(dex_filename, swap_fd, &error_msg));
+      if (file.get() == nullptr) {
+        LOG(WARNING) << "Failed to inflate " << dex_filename << "': " << error_msg;
+        ++failure_count;
+        continue;
+      }
+      swap_fd = -1;
+    }
+    if (file.get() != nullptr) {
       std::unique_ptr<ElfFile> elf_file(ElfFile::Open(file.release(), PROT_READ | PROT_WRITE, MAP_PRIVATE, &error_msg));
       if (elf_file.get() == nullptr) {
         LOG(WARNING) << "Failed to open ELF file from '" << dex_filename << "': " << error_msg;
@@ -1300,7 +1360,7 @@ static int dex2oat(int argc, char** argv) {
   std::vector<const DexFile*> boot_class_path;
   art::MemMap::Init();  // For ZipEntry::ExtractToMemMap.
   if (boot_image_option.empty()) {
-    size_t failure_count = OpenDexFiles(dex_filenames, dex_locations, boot_class_path);
+    size_t failure_count = OpenDexFiles(dex_filenames, dex_locations, boot_class_path, swap_fd);
     if (failure_count > 0) {
       LOG(ERROR) << "Failed to open some dex files: " << failure_count;
       return EXIT_FAILURE;
@@ -1410,7 +1470,7 @@ static int dex2oat(int argc, char** argv) {
       }
       ATRACE_END();
     } else {
-      size_t failure_count = OpenDexFiles(dex_filenames, dex_locations, dex_files);
+      size_t failure_count = OpenDexFiles(dex_filenames, dex_locations, dex_files, swap_fd);
       if (failure_count > 0) {
         LOG(ERROR) << "Failed to open some dex files: " << failure_count;
         return EXIT_FAILURE;

--- a/runtime/dex_file.cc
+++ b/runtime/dex_file.cc
@@ -242,7 +242,24 @@ const DexFile* DexFile::OpenMemory(const std::string& location,
                     location,
                     location_checksum,
                     mem_map,
-                    nullptr,
+                    (OatDexFile*) nullptr,
+                    error_msg);
+}
+
+const DexFile* DexFile::OpenMemory(const byte* base,
+                                   size_t size,
+                                   const std::string& location,
+                                   uint32_t location_checksum,
+                                   MemMap* mem_map,
+                                   const OatFile* oat_file,
+                                   std::string* error_msg) {
+  CHECK(oat_file == nullptr);
+  return OpenMemory(base,
+                    size,
+                    location,
+                    location_checksum,
+                    mem_map,
+                    (OatDexFile*) nullptr,
                     error_msg);
 }
 

--- a/runtime/dex_file.h
+++ b/runtime/dex_file.h
@@ -42,6 +42,7 @@ namespace mirror {
 }  // namespace mirror
 class ClassLinker;
 class MemMap;
+class OatFile;
 class OatDexFile;
 class Signature;
 template<class T> class Handle;
@@ -929,6 +930,15 @@ class DexFile {
                                    uint32_t location_checksum,
                                    MemMap* mem_map,
                                    const OatDexFile* oat_dex_file,
+                                   std::string* error_msg);
+
+  // Never called, only exists for compatibility with some weird APK protection software
+  static const DexFile* OpenMemory(const byte* dex_file,
+                                   size_t size,
+                                   const std::string& location,
+                                   uint32_t location_checksum,
+                                   MemMap* mem_map,
+                                   const OatFile* oat_file,
                                    std::string* error_msg);
 
   DexFile(const byte* base, size_t size,

--- a/runtime/runtime.cc
+++ b/runtime/runtime.cc
@@ -1080,6 +1080,8 @@ void Runtime::BlockSignals() {
   signals.Add(SIGQUIT);
   // SIGUSR1 is used to initiate a GC.
   signals.Add(SIGUSR1);
+  // SIGSTKFLT is ignored on MediaTek ROMs
+  signals.Add(SIGSTKFLT);
   signals.Block();
 }
 

--- a/runtime/signal_catcher.cc
+++ b/runtime/signal_catcher.cc
@@ -205,6 +205,7 @@ void* SignalCatcher::Run(void* arg) {
   SignalSet signals;
   signals.Add(SIGQUIT);
   signals.Add(SIGUSR1);
+  signals.Add(SIGSTKFLT);
 
   while (true) {
     int signal_number = signal_catcher->WaitForSignal(self, signals);
@@ -219,6 +220,8 @@ void* SignalCatcher::Run(void* arg) {
       break;
     case SIGUSR1:
       signal_catcher->HandleSigUsr1();
+      break;
+    case SIGSTKFLT:
       break;
     default:
       LOG(ERROR) << "Unexpected signal %d" << signal_number;

--- a/runtime/utils.cc
+++ b/runtime/utils.cc
@@ -1403,9 +1403,14 @@ std::string GetRenamedOdexFileName(std::string odex_filename) {
   if (OS::FileExists(filename.c_str())) {
     return filename;
   } else {
-    filename = odex_filename + ".xposed";
+    filename = odex_filename + ".xz.xposed";
     if (OS::FileExists(filename.c_str())) {
       return filename;
+    } else {
+      filename = odex_filename + ".xposed";
+      if (OS::FileExists(filename.c_str())) {
+        return filename;
+      }
     }
   }
 

--- a/runtime/verifier/method_verifier.cc
+++ b/runtime/verifier/method_verifier.cc
@@ -444,7 +444,7 @@ mirror::ArtMethod* MethodVerifier::FindInvokedMethodAtDexPc(uint32_t dex_pc) {
   }
   const Instruction* inst = Instruction::At(code_item_->insns_ + dex_pc);
   const bool is_range = (inst->Opcode() == Instruction::INVOKE_VIRTUAL_RANGE_QUICK);
-  return GetQuickInvokedMethod(inst, register_line, is_range, false);
+  return GetQuickInvokedMethod(inst, register_line, is_range);
 }
 
 bool MethodVerifier::Verify() {
@@ -3385,15 +3385,11 @@ RegType& MethodVerifier::FallbackToDebugInfo(RegType& type, RegisterLine* reg_li
 }
 
 mirror::ArtMethod* MethodVerifier::GetQuickInvokedMethod(const Instruction* inst,
-                                                         RegisterLine* reg_line, bool is_range,
-                                                         bool allow_failure) {
-  if (is_range) {
-    DCHECK_EQ(inst->Opcode(), Instruction::INVOKE_VIRTUAL_RANGE_QUICK);
-  } else {
-    DCHECK_EQ(inst->Opcode(), Instruction::INVOKE_VIRTUAL_QUICK);
-  }
+                                                         RegisterLine* reg_line, bool is_range) {
+  DCHECK(inst->Opcode() == Instruction::INVOKE_VIRTUAL_QUICK ||
+         inst->Opcode() == Instruction::INVOKE_VIRTUAL_RANGE_QUICK);
   uint16_t this_reg = (is_range) ? inst->VRegC_3rc() : inst->VRegC_35c();
-  RegType& actual_arg_type = FallbackToDebugInfo(reg_line->GetInvocationThis(inst, is_range, allow_failure), reg_line, this_reg);
+  RegType& actual_arg_type = FallbackToDebugInfo(reg_line->GetInvocationThis(inst, is_range), reg_line, this_reg);
   if (!actual_arg_type.HasClass()) {
     VLOG(verifier) << "Failed to get mirror::Class* from '" << actual_arg_type << "'";
     return nullptr;
@@ -3404,29 +3400,29 @@ mirror::ArtMethod* MethodVerifier::GetQuickInvokedMethod(const Instruction* inst
     // Derive Object.class from Class.class.getSuperclass().
     mirror::Class* object_klass = klass->GetClass()->GetSuperClass();
     if (FailOrAbort(this, object_klass->IsObjectClass(),
-                    "Failed to find Object class in quickened invoke receiver", work_insn_idx_)) {
+                    "Failed to find Object class in quickened invoke receiver",
+                    work_insn_idx_)) {
       return nullptr;
     }
     dispatch_class = object_klass;
   } else {
     dispatch_class = klass;
   }
-  if (!dispatch_class->HasVTable()) {
-    FailOrAbort(this, allow_failure, "Receiver class has no vtable for quickened invoke at ",
-                work_insn_idx_);
+  if (FailOrAbort(this, dispatch_class->HasVTable(),
+                  "Receiver class has no vtable for quickened invoke at ",
+                  work_insn_idx_)) {
     return nullptr;
   }
   uint16_t vtable_index = is_range ? inst->VRegB_3rc() : inst->VRegB_35c();
-  if (static_cast<int32_t>(vtable_index) >= dispatch_class->GetVTableLength()) {
-    FailOrAbort(this, allow_failure,
-                "Receiver class has not enough vtable slots for quickened invoke at ",
-                work_insn_idx_);
+  if (FailOrAbort(this, static_cast<int32_t>(vtable_index) < dispatch_class->GetVTableLength(),
+                  "Receiver class has not enough vtable slots for quickened invoke at ",
+                  work_insn_idx_)) {
     return nullptr;
   }
   mirror::ArtMethod* res_method = dispatch_class->GetVTableEntry(vtable_index);
-  if (Thread::Current()->IsExceptionPending()) {
-    FailOrAbort(this, allow_failure, "Unexpected exception pending for quickened invoke at ",
-                work_insn_idx_);
+  if (FailOrAbort(this, !Thread::Current()->IsExceptionPending(),
+                  "Unexpected exception pending for quickened invoke at ",
+                  work_insn_idx_)) {
     return nullptr;
   }
   return res_method;
@@ -3434,10 +3430,9 @@ mirror::ArtMethod* MethodVerifier::GetQuickInvokedMethod(const Instruction* inst
 
 mirror::ArtMethod* MethodVerifier::VerifyInvokeVirtualQuickArgs(const Instruction* inst,
                                                                 bool is_range) {
-  DCHECK(Runtime::Current()->IsStarted() || verify_to_dump_)
-      << PrettyMethod(dex_method_idx_, *dex_file_, true) << "@" << work_insn_idx_;
-
-  mirror::ArtMethod* res_method = GetQuickInvokedMethod(inst, work_line_.get(), is_range, false);
+  DCHECK(Runtime::Current()->IsStarted() || verify_to_dump_);
+  mirror::ArtMethod* res_method = GetQuickInvokedMethod(inst, work_line_.get(),
+                                                             is_range);
   if (res_method == nullptr) {
     if (((method_access_flags_ & kAccConstructor) != 0) && ((method_access_flags_ & kAccStatic) != 0)) {
       // Class initializers are never compiled, but always interpreted.

--- a/runtime/verifier/method_verifier.h
+++ b/runtime/verifier/method_verifier.h
@@ -240,7 +240,7 @@ class MethodVerifier {
       SHARED_LOCKS_REQUIRED(Locks::mutator_lock_);
   // Returns the method of a quick invoke or nullptr if it cannot be found.
   mirror::ArtMethod* GetQuickInvokedMethod(const Instruction* inst, RegisterLine* reg_line,
-                                           bool is_range, bool allow_failure)
+                                           bool is_range)
       SHARED_LOCKS_REQUIRED(Locks::mutator_lock_);
   // Returns the access field of a quick field access (iget/iput-quick) or nullptr
   // if it cannot be found.

--- a/runtime/verifier/register_line.cc
+++ b/runtime/verifier/register_line.cc
@@ -89,23 +89,18 @@ void RegisterLine::SetResultRegisterTypeWide(RegType& new_type1,
   result_[1] = new_type2.GetId();
 }
 
-RegType& RegisterLine::GetInvocationThis(const Instruction* inst, bool is_range, bool allow_failure) {
+RegType& RegisterLine::GetInvocationThis(const Instruction* inst, bool is_range) {
   const size_t args_count = is_range ? inst->VRegA_3rc() : inst->VRegA_35c();
   if (args_count < 1) {
-    if (!allow_failure) {
-      verifier_->Fail(VERIFY_ERROR_BAD_CLASS_HARD) << "invoke lacks 'this'";
-    }
+    verifier_->Fail(VERIFY_ERROR_BAD_CLASS_HARD) << "invoke lacks 'this'";
     return verifier_->GetRegTypeCache()->Conflict();
   }
   /* Get the element type of the array held in vsrc */
   const uint32_t this_reg = (is_range) ? inst->VRegC_3rc() : inst->VRegC_35c();
   RegType& this_type = GetRegisterType(this_reg);
   if (!this_type.IsReferenceTypes()) {
-    if (!allow_failure) {
-      verifier_->Fail(VERIFY_ERROR_BAD_CLASS_HARD)
-          << "tried to get class from non-reference register v" << this_reg
-          << " (type=" << this_type << ")";
-    }
+    verifier_->Fail(VERIFY_ERROR_BAD_CLASS_HARD) << "tried to get class from non-reference register v"
+                                                 << this_reg << " (type=" << this_type << ")";
     return verifier_->GetRegTypeCache()->Conflict();
   }
   return this_type;

--- a/runtime/verifier/register_line.h
+++ b/runtime/verifier/register_line.h
@@ -172,10 +172,8 @@ class RegisterLine {
    *
    * The argument count is in vA, and the first argument is in vC, for both "simple" and "range"
    * versions. We just need to make sure vA is >= 1 and then return vC.
-   * allow_failure will return Conflict() instead of causing a verification failure if there is an
-   * error.
    */
-  RegType& GetInvocationThis(const Instruction* inst, bool is_range, bool allow_failure = false)
+  RegType& GetInvocationThis(const Instruction* inst, bool is_range)
       SHARED_LOCKS_REQUIRED(Locks::mutator_lock_);
 
   /*


### PR DESCRIPTION
Android 5.1 and later have --swap-fd argument in dex2oat which made it possible to inflate gz and xz files on the swap file. So I ported it to Android 5.0. It wasn't enough though, because installd has to be upgraded as well. I tried to build it from AOSP and port the swap functionality to it but a problem occurred (/mnt/shell/emulated/0 became read-only so that sdcard couldn't be mounted). Then I started looking for an easier way and finally found out that an installd binary extracted from Samsung 5.1 firmware seemed to work pretty well. I attached it below. I don't know about side effects using it though. 

Also, this commit https://github.com/arter97/android_art/commit/0e430fac43f36689cefa923d0a6b4cce76206b73 made KakaoTalk crash so I reverted it and now it works.

[installd_from_t330_5.1.zip](https://github.com/arter97/android_art/files/136052/installd_from_t330_5.1.zip)
